### PR TITLE
fix: yasb handle the screen geometry on config refresh

### DIFF
--- a/src/core/bar.py
+++ b/src/core/bar.py
@@ -100,6 +100,9 @@ class Bar(QWidget):
                 scale_screen_height
             )
 
+    def closeEvent(self, event):
+        self.try_remove_app_bar()
+
     def try_remove_app_bar(self) -> None:
         if self.app_bar_manager:
             self.app_bar_manager.remove_appbar()


### PR DESCRIPTION
Fix problem with config refresh not handling the screen geometry properly. (It would get hidden behind all Komorebi windows.)

To reproduce the issue: Open YASB and then change the configuration file.
At least on my setup what would happen is the bar would close and reopen, but Komorebi/Windows wouldn't realize it's supposed to be at the top, so it would be hidden behind the Komorebi-handled windows.