### PR TITLE
Small fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ watchdog
 winsdk
 comtypes
 pycaw
+winshell

--- a/src/core/validation/widgets/komorebi/workspaces.py
+++ b/src/core/validation/widgets/komorebi/workspaces.py
@@ -4,6 +4,7 @@ DEFAULTS = {
     'label_default_name': '',
     'label_zero_index': False,
     'hide_empty_workspaces': False,
+    'preview_workspace': False
 }
 
 VALIDATION_SCHEMA = {
@@ -26,5 +27,9 @@ VALIDATION_SCHEMA = {
     'hide_empty_workspaces': {
         'type': 'boolean',
         'default': DEFAULTS['hide_empty_workspaces']
-    }
+    },
+    'preview_workspace': {
+        'type': 'boolean',
+        'default': DEFAULTS['preview_workspace']
+    },
 }


### PR DESCRIPTION
winshell was missing from requirements.txt and used by tray.py
Also added preview_workspace back to validation. It's ok if the feature is broken, but not having it there will break configs.