### PR TITLE
widget(active layout): react to workspace change

### DIFF
--- a/src/core/widgets/komorebi/active_layout.py
+++ b/src/core/widgets/komorebi/active_layout.py
@@ -114,6 +114,8 @@ class ActiveLayoutWidget(BaseWidget):
     def _register_signals_and_events(self):
         active_layout_change_event_watchlist = [
             KomorebiEvent.ChangeLayout,
+            KomorebiEvent.FocusWorkspaceNumber,
+            KomorebiEvent.FocusMonitorWorkspaceNumber,
             KomorebiEvent.TogglePause,
             KomorebiEvent.ToggleTiling,
             KomorebiEvent.ToggleMonocle,


### PR DESCRIPTION
The layout wouldn't match the workspace if you switched.